### PR TITLE
Added methods to register workers

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,15 +32,18 @@ import { TemporalModule } from 'nestjs-temporal';
 
 @Module({
   imports: [
-    TemporalModule.forRoot({
-      taskQueue: 'default',
-      workflowsPath: require.resolve('./temporal/workflow'),
+    TemporalModule.registerWorker({
+      workerOptions: {
+        taskQueue: 'default',
+        workflowsPath: require.resolve('./temporal/workflow'),
+      },
     }),
-    
+
     TemporalModule.registerClient(),
   ],
 })
-export class AppModule {}
+export class AppModule {
+}
 ```
 
 ```ts
@@ -69,7 +72,7 @@ import { proxyActivities } from '@temporalio/workflow';
 // Only import the activity types
 import { IGreetingActivity } from '../activities';
 
-const { greeting, reverseGreeting } = proxyActivities<IGreetingActivity>({
+const { greeting } = proxyActivities<IGreetingActivity>({
   startToCloseTimeout: '1 minute',
 });
 
@@ -113,7 +116,7 @@ import * as path from 'path';
 
 @Module({
   imports: [
-    TempModule.forRootAsync({
+    TemporalModule.registerWorkerAsync({
       imports: [ConfigModule],
       inject: [ConfigService],
       useFactory: async (config: ConfigService) => {
@@ -127,9 +130,11 @@ import * as path from 'path';
         });
 
         return {
-          connection,
-          taskQueue: 'default',
-          workflowBundle,
+          workerOptions: {
+            connection,
+            taskQueue: 'default',
+            workflowBundle,
+          }
         };
       },
     }),
@@ -166,7 +171,58 @@ import { Connection } from '@temporalio/client';
 })
 export class ClientModule {}
 ```
+## Multiple workers
 
+Multiple workers can be registered by making multiple calls to `TemporalModule.registerWorker` or 
+`TemporalModule.registerWorkerAsync`.
+
+You must explicitly specify your activity classes when registering multiple workers; otherwise, the workers may 
+register all activities marked by `@Activity()`. You may find it more convenient to import dynamic worker module into 
+the module that actually contains the workflow and activities rather than your root `AppModule`. 
+
+```ts
+// Register the client once at the app level
+import { Module } from '@nestjs/common';
+import { TemporalModule } from 'nestjs-temporal';
+
+@Module({
+  imports: [
+    TemporalModule.registerClient(),
+  ],
+})
+export class AppModule {
+}
+
+// Configure Worker #1
+@Module({
+  imports: [
+    TemporalModule.registerWorker({
+      workerOptions: {
+        taskQueue: 'worker-1',
+        workflowsPath: require.resolve('./temporal/workflow-1'),
+      },
+      activityClasses: [Greeting1Activity],
+    }),
+  ],
+})
+export class Worker1Module {
+}
+
+// Configure Worker #2
+@Module({
+  imports: [
+    TemporalModule.registerWorker({
+      workerOptions: {
+        taskQueue: 'worker-2',
+        workflowsPath: require.resolve('./temporal/workflow-2'),
+      },
+      activityClasses: [SomeOtherActivity],
+    }),
+  ],
+})
+export class Worker2Module {
+}
+``` 
 
 ## People
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ import { proxyActivities } from '@temporalio/workflow';
 // Only import the activity types
 import { IGreetingActivity } from '../activities';
 
-const { greeting } = proxyActivities<IGreetingActivity>({
+const { greeting, reverseGreeting } = proxyActivities<IGreetingActivity>({
   startToCloseTimeout: '1 minute',
 });
 
@@ -166,50 +166,7 @@ import { Connection } from '@temporalio/client';
 })
 export class ClientModule {}
 ```
-## Multiple workers
 
-Multiple workers can be registered using `TemporalModule.registerWorker` or `TemporalModule.registerWorkerAsync`.
-You must explicitly specify your activity module(s) when registering the worker.
-
-```ts
-// Register the client once at the app level
-import { Module } from "@nestjs/common";
-import { TemporalModule } from "nestjs-temporal";
-
-@Module({
-  imports: [
-    TemporalModule.registerClient()
-  ]
-})
-export class AppModule {
-}
-
-// Configure Worker #1
-@Module({
-  imports: [
-    TemporalModule.registerWorker({
-        taskQueue: "worker-1",
-        workflowsPath: require.resolve("./temporal/workflow-1")
-      },
-      [Greeting1Activity])
-  ]
-})
-export class Worker1Module {
-}
-
-// Configure Worker #2
-@Module({
-  imports: [
-    TemporalModule.registerWorker({
-        taskQueue: "worker-2",
-        workflowsPath: require.resolve("./temporal/workflow-2")
-      },
-      [Greeting2Activity])
-  ]
-})
-export class Worker2Module {
-}
-``` 
 
 ## People
 

--- a/README.md
+++ b/README.md
@@ -204,6 +204,7 @@ export class AppModule {
       activityClasses: [Greeting1Activity],
     }),
   ],
+  providers: [Greeting1Activity],
 })
 export class Worker1Module {
 }
@@ -219,6 +220,7 @@ export class Worker1Module {
       activityClasses: [SomeOtherActivity],
     }),
   ],
+  providers: [SomeOtherActivity],
 })
 export class Worker2Module {
 }

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ import { proxyActivities } from '@temporalio/workflow';
 // Only import the activity types
 import { IGreetingActivity } from '../activities';
 
-const { greeting, reverseGreeting } = proxyActivities<IGreetingActivity>({
+const { greeting } = proxyActivities<IGreetingActivity>({
   startToCloseTimeout: '1 minute',
 });
 
@@ -166,7 +166,50 @@ import { Connection } from '@temporalio/client';
 })
 export class ClientModule {}
 ```
+## Multiple workers
 
+Multiple workers can be registered using `TemporalModule.registerWorker` or `TemporalModule.registerWorkerAsync`.
+You must explicitly specify your activity module(s) when registering the worker.
+
+```ts
+// Register the client once at the app level
+import { Module } from "@nestjs/common";
+import { TemporalModule } from "nestjs-temporal";
+
+@Module({
+  imports: [
+    TemporalModule.registerClient()
+  ]
+})
+export class AppModule {
+}
+
+// Configure Worker #1
+@Module({
+  imports: [
+    TemporalModule.registerWorker({
+        taskQueue: "worker-1",
+        workflowsPath: require.resolve("./temporal/workflow-1")
+      },
+      [Greeting1Activity])
+  ]
+})
+export class Worker1Module {
+}
+
+// Configure Worker #2
+@Module({
+  imports: [
+    TemporalModule.registerWorker({
+        taskQueue: "worker-2",
+        workflowsPath: require.resolve("./temporal/workflow-2")
+      },
+      [Greeting2Activity])
+  ]
+})
+export class Worker2Module {
+}
+``` 
 
 ## People
 

--- a/lib/temporal.constants.ts
+++ b/lib/temporal.constants.ts
@@ -8,3 +8,5 @@ export const TEMPORAL_WORKER_CONFIG = '_temporal_worker_config';
 export const TEMPORAL_CORE_CONFIG = '_temporal_core_config';
 export const TEMPORAL_CLIENT_CONFIG = '_temporal_client_config';
 export const TEMPORAL_CONNECTION_CONFIG = '_temporal_connection_config';
+export const TEMPORAL_ACTIVITIES_MODULES =
+  '_temporal_module_activities_modules';

--- a/lib/temporal.constants.ts
+++ b/lib/temporal.constants.ts
@@ -3,8 +3,3 @@ export const TEMPORAL_MODULE_ACTIVITY = '_temporal_module_activity';
 export const TEMPORAL_MODULE_WORKFLOW = '_temporal_module_workFlow';
 export const TEMPORAL_MODULE_WORKFLOW_METHOD =
   '_temporal_module_workflow_method';
-
-export const TEMPORAL_WORKER_CONFIG = '_temporal_worker_config';
-export const TEMPORAL_CORE_CONFIG = '_temporal_core_config';
-export const TEMPORAL_CLIENT_CONFIG = '_temporal_client_config';
-export const TEMPORAL_CONNECTION_CONFIG = '_temporal_connection_config';

--- a/lib/temporal.constants.ts
+++ b/lib/temporal.constants.ts
@@ -8,5 +8,3 @@ export const TEMPORAL_WORKER_CONFIG = '_temporal_worker_config';
 export const TEMPORAL_CORE_CONFIG = '_temporal_core_config';
 export const TEMPORAL_CLIENT_CONFIG = '_temporal_client_config';
 export const TEMPORAL_CONNECTION_CONFIG = '_temporal_connection_config';
-export const TEMPORAL_ACTIVITIES_MODULES =
-  '_temporal_module_activities_modules';

--- a/lib/temporal.explorer.ts
+++ b/lib/temporal.explorer.ts
@@ -1,12 +1,12 @@
 import {
+  Inject,
   Injectable,
   Logger,
   OnApplicationBootstrap,
   OnModuleDestroy,
   OnModuleInit,
 } from '@nestjs/common';
-import { DiscoveryService, MetadataScanner, ModuleRef } from '@nestjs/core';
-import { Injector } from '@nestjs/core/injector/injector';
+import { DiscoveryService, MetadataScanner } from '@nestjs/core';
 import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import {
   NativeConnection,
@@ -16,25 +16,22 @@ import {
   Worker,
   WorkerOptions,
 } from '@temporalio/worker';
-
 import {
-  TEMPORAL_CONNECTION_CONFIG,
-  TEMPORAL_CORE_CONFIG,
-  TEMPORAL_WORKER_CONFIG,
-} from './temporal.constants';
+  TEMPORAL_MODULE_OPTIONS_TOKEN,
+  TemporalModuleOptions,
+} from './temporal.module-definition';
 import { TemporalMetadataAccessor } from './temporal-metadata.accessors';
 
 @Injectable()
 export class TemporalExplorer
   implements OnModuleInit, OnModuleDestroy, OnApplicationBootstrap
 {
+  @Inject(TEMPORAL_MODULE_OPTIONS_TOKEN) private options: TemporalModuleOptions;
   private readonly logger = new Logger(TemporalExplorer.name);
-  private readonly injector = new Injector();
   private worker: Worker;
   private timerId: ReturnType<typeof setInterval>;
 
   constructor(
-    private readonly moduleRef: ModuleRef,
     private readonly discoveryService: DiscoveryService,
     private readonly metadataAccessor: TemporalMetadataAccessor,
     private readonly metadataScanner: MetadataScanner,
@@ -82,70 +79,59 @@ export class TemporalExplorer
       } as WorkerOptions;
       if (connectionOptions) {
         this.logger.verbose('Connecting to the Temporal server');
-        workerOptions.connection = await NativeConnection.connect(connectionOptions);
+        workerOptions.connection = await NativeConnection.connect(
+          connectionOptions,
+        );
       }
 
       this.logger.verbose('Creating a new Worker');
       this.worker = await Worker.create(
-        Object.assign(
-          workerOptions,
-          workerConfig,
-        ),
+        Object.assign(workerOptions, workerConfig),
       );
     }
   }
 
-  getWorkerConfigOptions(name?: string): WorkerOptions {
-    return this.moduleRef.get(TEMPORAL_WORKER_CONFIG || name, {
-      strict: false,
-    });
+  getWorkerConfigOptions(): WorkerOptions {
+    return this.options.workerOptions;
   }
 
-  getNativeConnectionOptions(name?: string): NativeConnectionOptions {
-    return this.moduleRef.get(TEMPORAL_CONNECTION_CONFIG || name, {
-      strict: false,
-    });
+  getNativeConnectionOptions(): NativeConnectionOptions | undefined {
+    return this.options.connectionOptions;
   }
 
-  getRuntimeOptions(name?: string): RuntimeOptions {
-    return this.moduleRef.get(TEMPORAL_CORE_CONFIG || name, { strict: false });
+  getRuntimeOptions(): RuntimeOptions | undefined {
+    return this.options.runtimeOptions;
   }
 
-  /**
-   *
-   * @returns
-   */
+  getActivityClasses(): object[] | undefined {
+    return this.options.activityClasses;
+  }
+
   async handleActivities() {
     const activitiesMethod = {};
 
+    const activityClasses = this.getActivityClasses();
     const activities: InstanceWrapper[] = this.discoveryService
       .getProviders()
-      .filter((wrapper: InstanceWrapper) =>
-        this.metadataAccessor.isActivities(
-          !wrapper.metatype || wrapper.inject
-            ? wrapper.instance?.constructor
-            : wrapper.metatype,
-        ),
+      .filter(
+        (wrapper: InstanceWrapper) =>
+          this.metadataAccessor.isActivities(
+            !wrapper.metatype || wrapper.inject
+              ? wrapper.instance?.constructor
+              : wrapper.metatype,
+          ) &&
+          (!activityClasses || activityClasses.includes(wrapper.metatype)),
       );
 
     activities.forEach((wrapper: InstanceWrapper) => {
-      const { instance, metatype } = wrapper;
+      const { instance } = wrapper;
       const isRequestScoped = !wrapper.isDependencyTreeStatic();
-
-      //
-      const activitiesOptions = this.metadataAccessor.getActivities(
-        instance.constructor || metatype,
-      );
 
       this.metadataScanner.scanFromPrototype(
         instance,
         Object.getPrototypeOf(instance),
         async (key: string) => {
           if (this.metadataAccessor.isActivity(instance[key])) {
-            const metadata = this.metadataAccessor.getActivity(instance[key]);
-
-            const args: unknown[] = [metadata?.name];
-
             if (isRequestScoped) {
               // TODO: handle request scoped
             } else {

--- a/lib/temporal.explorer.ts
+++ b/lib/temporal.explorer.ts
@@ -6,7 +6,6 @@ import {
   OnModuleInit,
 } from '@nestjs/common';
 import { DiscoveryService, MetadataScanner, ModuleRef } from '@nestjs/core';
-import { Injector } from '@nestjs/core/injector/injector';
 import { InstanceWrapper } from '@nestjs/core/injector/instance-wrapper';
 import {
   NativeConnection,
@@ -18,6 +17,7 @@ import {
 } from '@temporalio/worker';
 
 import {
+  TEMPORAL_ACTIVITIES_MODULES,
   TEMPORAL_CONNECTION_CONFIG,
   TEMPORAL_CORE_CONFIG,
   TEMPORAL_WORKER_CONFIG,
@@ -29,7 +29,6 @@ export class TemporalExplorer
   implements OnModuleInit, OnModuleDestroy, OnApplicationBootstrap
 {
   private readonly logger = new Logger(TemporalExplorer.name);
-  private readonly injector = new Injector();
   private worker: Worker;
   private timerId: ReturnType<typeof setInterval>;
 
@@ -82,70 +81,59 @@ export class TemporalExplorer
       } as WorkerOptions;
       if (connectionOptions) {
         this.logger.verbose('Connecting to the Temporal server');
-        workerOptions.connection = await NativeConnection.connect(connectionOptions);
+        workerOptions.connection = await NativeConnection.connect(
+          connectionOptions,
+        );
       }
 
       this.logger.verbose('Creating a new Worker');
       this.worker = await Worker.create(
-        Object.assign(
-          workerOptions,
-          workerConfig,
-        ),
+        Object.assign(workerOptions, workerConfig),
       );
     }
   }
 
   getWorkerConfigOptions(name?: string): WorkerOptions {
-    return this.moduleRef.get(TEMPORAL_WORKER_CONFIG || name, {
-      strict: false,
-    });
+    return this.moduleRef.get(TEMPORAL_WORKER_CONFIG || name);
   }
 
   getNativeConnectionOptions(name?: string): NativeConnectionOptions {
-    return this.moduleRef.get(TEMPORAL_CONNECTION_CONFIG || name, {
-      strict: false,
-    });
+    return this.moduleRef.get(TEMPORAL_CONNECTION_CONFIG || name);
   }
 
   getRuntimeOptions(name?: string): RuntimeOptions {
-    return this.moduleRef.get(TEMPORAL_CORE_CONFIG || name, { strict: false });
+    return this.moduleRef.get(TEMPORAL_CORE_CONFIG || name);
   }
 
-  /**
-   *
-   * @returns
-   */
+  getActivitiesModules(): any[] | undefined {
+    return this.moduleRef.get(TEMPORAL_ACTIVITIES_MODULES) || undefined;
+  }
+
   async handleActivities() {
     const activitiesMethod = {};
 
+    const activitiesModules = this.getActivitiesModules();
     const activities: InstanceWrapper[] = this.discoveryService
       .getProviders()
-      .filter((wrapper: InstanceWrapper) =>
-        this.metadataAccessor.isActivities(
-          !wrapper.metatype || wrapper.inject
-            ? wrapper.instance?.constructor
-            : wrapper.metatype,
-        ),
+      .filter(
+        (wrapper: InstanceWrapper) =>
+          this.metadataAccessor.isActivities(
+            !wrapper.metatype || wrapper.inject
+              ? wrapper.instance?.constructor
+              : wrapper.metatype,
+          ) &&
+          (!activitiesModules || activitiesModules.includes(wrapper.metatype)),
       );
 
     activities.forEach((wrapper: InstanceWrapper) => {
-      const { instance, metatype } = wrapper;
+      const { instance } = wrapper;
       const isRequestScoped = !wrapper.isDependencyTreeStatic();
-
-      //
-      const activitiesOptions = this.metadataAccessor.getActivities(
-        instance.constructor || metatype,
-      );
 
       this.metadataScanner.scanFromPrototype(
         instance,
         Object.getPrototypeOf(instance),
         async (key: string) => {
           if (this.metadataAccessor.isActivity(instance[key])) {
-            const metadata = this.metadataAccessor.getActivity(instance[key]);
-
-            const args: unknown[] = [metadata?.name];
-
             if (isRequestScoped) {
               // TODO: handle request scoped
             } else {

--- a/lib/temporal.module-definition.ts
+++ b/lib/temporal.module-definition.ts
@@ -1,0 +1,22 @@
+import {
+  NativeConnectionOptions,
+  RuntimeOptions,
+  WorkerOptions,
+} from '@temporalio/worker';
+import { ConfigurableModuleBuilder } from '@nestjs/common';
+
+export interface TemporalModuleOptions {
+  workerOptions: WorkerOptions;
+  connectionOptions?: NativeConnectionOptions;
+  runtimeOptions?: RuntimeOptions;
+  activityClasses?: object[];
+}
+
+export const {
+  ConfigurableModuleClass,
+  MODULE_OPTIONS_TOKEN: TEMPORAL_MODULE_OPTIONS_TOKEN,
+  OPTIONS_TYPE: TEMPORAL_MODULE_OPTIONS_TYPE,
+  ASYNC_OPTIONS_TYPE: TEMPORAL_MODULE_ASYNC_OPTIONS_TYPE,
+} = new ConfigurableModuleBuilder<TemporalModuleOptions>()
+  .setClassMethodName('registerWorker')
+  .build();

--- a/lib/temporal.module.ts
+++ b/lib/temporal.module.ts
@@ -2,24 +2,23 @@ import { DynamicModule, Module, Provider } from '@nestjs/common';
 import { DiscoveryModule } from '@nestjs/core';
 import {
   NativeConnectionOptions,
-  RuntimeOptions,
   WorkerOptions,
+  RuntimeOptions,
 } from '@temporalio/worker';
 
 import { TemporalMetadataAccessor } from './temporal-metadata.accessors';
 import { TemporalExplorer } from './temporal.explorer';
 import {
-  SharedConnectionAsyncConfiguration,
-  SharedRuntimeAsyncConfiguration,
   SharedWorkerAsyncConfiguration,
-  SharedWorkflowClientOptions,
   TemporalModuleOptions,
+  SharedRuntimeAsyncConfiguration,
+  SharedConnectionAsyncConfiguration,
+  SharedWorkflowClientOptions,
 } from './interfaces';
 import {
-  TEMPORAL_ACTIVITIES_MODULES,
-  TEMPORAL_CONNECTION_CONFIG,
   TEMPORAL_CORE_CONFIG,
   TEMPORAL_WORKER_CONFIG,
+  TEMPORAL_CONNECTION_CONFIG,
 } from './temporal.constants';
 import { createClientProviders } from './temporal.providers';
 import { createAsyncProvider, createClientAsyncProvider } from './utils';
@@ -31,135 +30,6 @@ export class TemporalModule {
     connectionConfig?: NativeConnectionOptions,
     runtimeConfig?: RuntimeOptions,
   ): DynamicModule {
-    const providers = this.createConfigProviders(
-      workerConfig,
-      connectionConfig,
-      runtimeConfig,
-    );
-
-    return {
-      global: true,
-      module: TemporalModule,
-      providers,
-      imports: [TemporalModule.registerCore()],
-    };
-  }
-
-  static forRootAsync(
-    asyncWorkerConfig: SharedWorkerAsyncConfiguration,
-    asyncConnectionConfig?: SharedConnectionAsyncConfiguration,
-    asyncRuntimeConfig?: SharedRuntimeAsyncConfiguration,
-  ): DynamicModule {
-    const providers: Provider[] = this.createAsyncConfigProviders(
-      asyncWorkerConfig,
-      asyncConnectionConfig,
-      asyncRuntimeConfig,
-    );
-
-    return {
-      global: true,
-      module: TemporalModule,
-      providers: [...providers],
-      imports: [TemporalModule.registerCore()],
-      exports: providers,
-    };
-  }
-
-  /**
-   * Register a single worker.
-   *
-   * This can be used multiple times to register multiple workers.
-   */
-  static registerWorker(
-    workerConfig: WorkerOptions,
-    activityModules: any[],
-    connectionConfig?: NativeConnectionOptions,
-    runtimeConfig?: RuntimeOptions,
-  ): DynamicModule {
-    const providers = this.createConfigProviders(
-      workerConfig,
-      connectionConfig,
-      runtimeConfig,
-    );
-    const activitiesProvider: Provider = {
-      provide: TEMPORAL_ACTIVITIES_MODULES,
-      useValue: activityModules,
-    };
-
-    return {
-      module: TemporalModule,
-      providers: [
-        ...providers,
-        activitiesProvider,
-        TemporalExplorer,
-        TemporalMetadataAccessor,
-      ],
-      imports: [DiscoveryModule],
-    };
-  }
-
-  /**
-   * Register a single worker.
-   *
-   * This can be used multiple times to register multiple workers.
-   */
-  static registerWorkerAsync(
-    asyncWorkerConfig: SharedWorkerAsyncConfiguration,
-    activityModules: any[],
-    asyncConnectionConfig?: SharedConnectionAsyncConfiguration,
-    asyncRuntimeConfig?: SharedRuntimeAsyncConfiguration,
-  ): DynamicModule {
-    const providers: Provider[] = this.createAsyncConfigProviders(
-      asyncWorkerConfig,
-      asyncConnectionConfig,
-      asyncRuntimeConfig,
-    );
-    const activitiesProvider: Provider = {
-      provide: TEMPORAL_ACTIVITIES_MODULES,
-      useValue: activityModules,
-    };
-
-    return {
-      module: TemporalModule,
-      providers: [
-        ...providers,
-        activitiesProvider,
-        TemporalExplorer,
-        TemporalMetadataAccessor,
-      ],
-      imports: [DiscoveryModule],
-    };
-  }
-
-  static registerClient(options?: TemporalModuleOptions): DynamicModule {
-    const createClientProvider = createClientProviders([].concat(options));
-    return {
-      global: true,
-      module: TemporalModule,
-      providers: createClientProvider,
-      exports: createClientProvider,
-    };
-  }
-  static registerClientAsync(
-    asyncSharedWorkflowClientOptions: SharedWorkflowClientOptions,
-  ): DynamicModule {
-    const providers = createClientAsyncProvider(
-      asyncSharedWorkflowClientOptions,
-    );
-
-    return {
-      global: true,
-      module: TemporalModule,
-      providers,
-      exports: providers,
-    };
-  }
-
-  protected static createConfigProviders(
-    workerConfig: WorkerOptions,
-    connectionConfig: NativeConnectionOptions,
-    runtimeConfig: RuntimeOptions,
-  ) {
     const workerConfigProvider: Provider = {
       provide: TEMPORAL_WORKER_CONFIG,
       useValue: workerConfig || null,
@@ -175,26 +45,66 @@ export class TemporalModule {
       useValue: runtimeConfig || null,
     };
 
-    return [
+    const providers: Provider[] = [
       workerConfigProvider,
       connectionConfigProvider,
       runtimeConfigProvider,
     ];
+
+    return {
+      global: true,
+      module: TemporalModule,
+      providers,
+      imports: [TemporalModule.registerCore()],
+    };
   }
 
-  protected static createAsyncConfigProviders(
+  static forRootAsync(
     asyncWorkerConfig: SharedWorkerAsyncConfiguration,
-    asyncConnectionConfig: SharedConnectionAsyncConfiguration,
-    asyncRuntimeConfig: SharedRuntimeAsyncConfiguration,
-  ) {
-    return [
+    asyncConnectionConfig?: SharedConnectionAsyncConfiguration,
+    asyncRuntimeConfig?: SharedRuntimeAsyncConfiguration,
+  ): DynamicModule {
+    const providers: Provider[] = [
       createAsyncProvider(TEMPORAL_WORKER_CONFIG, asyncWorkerConfig),
-      createAsyncProvider(TEMPORAL_CONNECTION_CONFIG, asyncConnectionConfig),
+      createAsyncProvider(
+        TEMPORAL_CONNECTION_CONFIG,
+        asyncConnectionConfig,
+      ),
       createAsyncProvider(TEMPORAL_CORE_CONFIG, asyncRuntimeConfig),
     ];
+
+    return {
+      global: true,
+      module: TemporalModule,
+      providers: [...providers],
+      imports: [TemporalModule.registerCore()],
+      exports: providers,
+    };
   }
 
-  private static registerCore(): DynamicModule {
+  static registerClient(options?: TemporalModuleOptions): DynamicModule {
+    const createClientProvider = createClientProviders([].concat(options));
+    return {
+      global: true,
+      module: TemporalModule,
+      providers: createClientProvider,
+      exports: createClientProvider,
+    };
+  }
+  static registerClientAsync(
+    asyncSharedWorkflowClientOptions: SharedWorkflowClientOptions
+  ): DynamicModule {
+    const providers = createClientAsyncProvider(asyncSharedWorkflowClientOptions);
+
+    return {
+      global: true,
+      module: TemporalModule,
+      providers,
+      exports: providers,
+    };
+  }
+
+  private static registerCore() {
     return {
       global: true,
       module: TemporalModule,

--- a/lib/temporal.module.ts
+++ b/lib/temporal.module.ts
@@ -2,23 +2,24 @@ import { DynamicModule, Module, Provider } from '@nestjs/common';
 import { DiscoveryModule } from '@nestjs/core';
 import {
   NativeConnectionOptions,
-  WorkerOptions,
   RuntimeOptions,
+  WorkerOptions,
 } from '@temporalio/worker';
 
 import { TemporalMetadataAccessor } from './temporal-metadata.accessors';
 import { TemporalExplorer } from './temporal.explorer';
 import {
-  SharedWorkerAsyncConfiguration,
-  TemporalModuleOptions,
-  SharedRuntimeAsyncConfiguration,
   SharedConnectionAsyncConfiguration,
+  SharedRuntimeAsyncConfiguration,
+  SharedWorkerAsyncConfiguration,
   SharedWorkflowClientOptions,
+  TemporalModuleOptions,
 } from './interfaces';
 import {
+  TEMPORAL_ACTIVITIES_MODULES,
+  TEMPORAL_CONNECTION_CONFIG,
   TEMPORAL_CORE_CONFIG,
   TEMPORAL_WORKER_CONFIG,
-  TEMPORAL_CONNECTION_CONFIG,
 } from './temporal.constants';
 import { createClientProviders } from './temporal.providers';
 import { createAsyncProvider, createClientAsyncProvider } from './utils';
@@ -30,6 +31,135 @@ export class TemporalModule {
     connectionConfig?: NativeConnectionOptions,
     runtimeConfig?: RuntimeOptions,
   ): DynamicModule {
+    const providers = this.createConfigProviders(
+      workerConfig,
+      connectionConfig,
+      runtimeConfig,
+    );
+
+    return {
+      global: true,
+      module: TemporalModule,
+      providers,
+      imports: [TemporalModule.registerCore()],
+    };
+  }
+
+  static forRootAsync(
+    asyncWorkerConfig: SharedWorkerAsyncConfiguration,
+    asyncConnectionConfig?: SharedConnectionAsyncConfiguration,
+    asyncRuntimeConfig?: SharedRuntimeAsyncConfiguration,
+  ): DynamicModule {
+    const providers: Provider[] = this.createAsyncConfigProviders(
+      asyncWorkerConfig,
+      asyncConnectionConfig,
+      asyncRuntimeConfig,
+    );
+
+    return {
+      global: true,
+      module: TemporalModule,
+      providers: [...providers],
+      imports: [TemporalModule.registerCore()],
+      exports: providers,
+    };
+  }
+
+  /**
+   * Register a single worker.
+   *
+   * This can be used multiple times to register multiple workers.
+   */
+  static registerWorker(
+    workerConfig: WorkerOptions,
+    activityModules: any[],
+    connectionConfig?: NativeConnectionOptions,
+    runtimeConfig?: RuntimeOptions,
+  ): DynamicModule {
+    const providers = this.createConfigProviders(
+      workerConfig,
+      connectionConfig,
+      runtimeConfig,
+    );
+    const activitiesProvider: Provider = {
+      provide: TEMPORAL_ACTIVITIES_MODULES,
+      useValue: activityModules,
+    };
+
+    return {
+      module: TemporalModule,
+      providers: [
+        ...providers,
+        activitiesProvider,
+        TemporalExplorer,
+        TemporalMetadataAccessor,
+      ],
+      imports: [DiscoveryModule],
+    };
+  }
+
+  /**
+   * Register a single worker.
+   *
+   * This can be used multiple times to register multiple workers.
+   */
+  static registerWorkerAsync(
+    asyncWorkerConfig: SharedWorkerAsyncConfiguration,
+    activityModules: any[],
+    asyncConnectionConfig?: SharedConnectionAsyncConfiguration,
+    asyncRuntimeConfig?: SharedRuntimeAsyncConfiguration,
+  ): DynamicModule {
+    const providers: Provider[] = this.createAsyncConfigProviders(
+      asyncWorkerConfig,
+      asyncConnectionConfig,
+      asyncRuntimeConfig,
+    );
+    const activitiesProvider: Provider = {
+      provide: TEMPORAL_ACTIVITIES_MODULES,
+      useValue: activityModules,
+    };
+
+    return {
+      module: TemporalModule,
+      providers: [
+        ...providers,
+        activitiesProvider,
+        TemporalExplorer,
+        TemporalMetadataAccessor,
+      ],
+      imports: [DiscoveryModule],
+    };
+  }
+
+  static registerClient(options?: TemporalModuleOptions): DynamicModule {
+    const createClientProvider = createClientProviders([].concat(options));
+    return {
+      global: true,
+      module: TemporalModule,
+      providers: createClientProvider,
+      exports: createClientProvider,
+    };
+  }
+  static registerClientAsync(
+    asyncSharedWorkflowClientOptions: SharedWorkflowClientOptions,
+  ): DynamicModule {
+    const providers = createClientAsyncProvider(
+      asyncSharedWorkflowClientOptions,
+    );
+
+    return {
+      global: true,
+      module: TemporalModule,
+      providers,
+      exports: providers,
+    };
+  }
+
+  protected static createConfigProviders(
+    workerConfig: WorkerOptions,
+    connectionConfig: NativeConnectionOptions,
+    runtimeConfig: RuntimeOptions,
+  ) {
     const workerConfigProvider: Provider = {
       provide: TEMPORAL_WORKER_CONFIG,
       useValue: workerConfig || null,
@@ -45,66 +175,26 @@ export class TemporalModule {
       useValue: runtimeConfig || null,
     };
 
-    const providers: Provider[] = [
+    return [
       workerConfigProvider,
       connectionConfigProvider,
       runtimeConfigProvider,
     ];
-
-    return {
-      global: true,
-      module: TemporalModule,
-      providers,
-      imports: [TemporalModule.registerCore()],
-    };
   }
 
-  static forRootAsync(
+  protected static createAsyncConfigProviders(
     asyncWorkerConfig: SharedWorkerAsyncConfiguration,
-    asyncConnectionConfig?: SharedConnectionAsyncConfiguration,
-    asyncRuntimeConfig?: SharedRuntimeAsyncConfiguration,
-  ): DynamicModule {
-    const providers: Provider[] = [
+    asyncConnectionConfig: SharedConnectionAsyncConfiguration,
+    asyncRuntimeConfig: SharedRuntimeAsyncConfiguration,
+  ) {
+    return [
       createAsyncProvider(TEMPORAL_WORKER_CONFIG, asyncWorkerConfig),
-      createAsyncProvider(
-        TEMPORAL_CONNECTION_CONFIG,
-        asyncConnectionConfig,
-      ),
+      createAsyncProvider(TEMPORAL_CONNECTION_CONFIG, asyncConnectionConfig),
       createAsyncProvider(TEMPORAL_CORE_CONFIG, asyncRuntimeConfig),
     ];
-
-    return {
-      global: true,
-      module: TemporalModule,
-      providers: [...providers],
-      imports: [TemporalModule.registerCore()],
-      exports: providers,
-    };
   }
 
-  static registerClient(options?: TemporalModuleOptions): DynamicModule {
-    const createClientProvider = createClientProviders([].concat(options));
-    return {
-      global: true,
-      module: TemporalModule,
-      providers: createClientProvider,
-      exports: createClientProvider,
-    };
-  }
-  static registerClientAsync(
-    asyncSharedWorkflowClientOptions: SharedWorkflowClientOptions
-  ): DynamicModule {
-    const providers = createClientAsyncProvider(asyncSharedWorkflowClientOptions);
-
-    return {
-      global: true,
-      module: TemporalModule,
-      providers,
-      exports: providers,
-    };
-  }
-
-  private static registerCore() {
+  private static registerCore(): DynamicModule {
     return {
       global: true,
       module: TemporalModule,


### PR DESCRIPTION
These methods can be used in lieu of forRoot and forRootAsync in order to register multiple modules as independent workers with separate activities and workflows.

Fixes #22 