### PR TITLE
Squashing client and worker shutdown errors

### DIFF
--- a/lib/temporal.explorer.ts
+++ b/lib/temporal.explorer.ts
@@ -50,7 +50,12 @@ export class TemporalExplorer
   }
 
   onModuleDestroy() {
-    this.worker?.shutdown();
+    try {
+      this.worker?.shutdown();
+    } catch (err: any) {
+      this.logger.warn('Temporal worker was not cleanly shutdown.', { err });
+    }
+
     this.clearInterval();
   }
 
@@ -82,15 +87,14 @@ export class TemporalExplorer
       } as WorkerOptions;
       if (connectionOptions) {
         this.logger.verbose('Connecting to the Temporal server');
-        workerOptions.connection = await NativeConnection.connect(connectionOptions);
+        workerOptions.connection = await NativeConnection.connect(
+          connectionOptions,
+        );
       }
 
       this.logger.verbose('Creating a new Worker');
       this.worker = await Worker.create(
-        Object.assign(
-          workerOptions,
-          workerConfig,
-        ),
+        Object.assign(workerOptions, workerConfig),
       );
     }
   }

--- a/lib/utils/client.util.ts
+++ b/lib/utils/client.util.ts
@@ -1,8 +1,16 @@
-import { OnApplicationShutdown } from "@nestjs/common";
-import { WorkflowClient, WorkflowClientOptions } from "@temporalio/client";
+import { OnApplicationShutdown } from '@nestjs/common';
+import { WorkflowClient, WorkflowClientOptions } from '@temporalio/client';
 
 export function assignOnAppShutdownHook(client: WorkflowClient) {
-  (client as unknown as OnApplicationShutdown).onApplicationShutdown = client.connection.close;
+  (client as unknown as OnApplicationShutdown).onApplicationShutdown =
+    async () =>
+      client.connection
+        ?.close()
+        .catch((reason) =>
+          console.error(
+            `Temporal client connection was not cleanly closed: ${reason}`,
+          ),
+        );
   return client;
 }
 


### PR DESCRIPTION
If the client connection or worker is not cleanly shutdown, a log entry is created and the exception is squashed. This ensures we don't unnecessarily crash systems that are already in the process of shutting down.

Fixes #38 