### PR TITLE
fix: resolve activity classes through the DI container

### DIFF
--- a/lib/temporal.explorer.ts
+++ b/lib/temporal.explorer.ts
@@ -146,14 +146,26 @@ export class TemporalExplorer
   }
 
   /**
-   * Gets the activity classes to register with this worker.
-   * If undefined, all discovered activities will be registered.
-   * Can be either class constructors or InstanceWrappers.
+   * Resolves the activity providers to register with this worker.
+   *
+   * Activities are looked up in the DI container so that each one is the
+   * container-managed instance, with its dependencies injected. When
+   * `activityClasses` is undefined, every discovered activity is registered.
    */
-  private getActivityClasses(): (InstanceWrapper | Function)[] | undefined {
-    return this.options.activityClasses as
-      | (InstanceWrapper | Function)[]
-      | undefined;
+  private getActivityClasses(): InstanceWrapper[] {
+    const activityClasses = this.options.activityClasses;
+
+    return this.discoveryService
+      .getProviders()
+      .filter(
+        (wrapper: InstanceWrapper) =>
+          this.metadataAccessor.isActivities(
+            !wrapper.metatype || wrapper.inject
+              ? wrapper.instance?.constructor
+              : wrapper.metatype,
+          ) &&
+          (!activityClasses || activityClasses.includes(wrapper.metatype)),
+      );
   }
 
   /**
@@ -166,19 +178,14 @@ export class TemporalExplorer
     }
 
     const activityClasses = this.getActivityClasses();
-    if (!activityClasses || activityClasses.length === 0) {
+    if (activityClasses.length === 0) {
       return;
     }
 
     const activityMethods: Record<string, string[]> = {};
 
-    activityClasses.forEach((classOrWrapper: InstanceWrapper | Function) => {
-      // Handle both InstanceWrapper and class constructor
-      const wrapper = classOrWrapper as InstanceWrapper;
-      const instance =
-        'instance' in wrapper && wrapper.instance
-          ? wrapper.instance
-          : new (classOrWrapper as new () => unknown)();
+    activityClasses.forEach((wrapper: InstanceWrapper) => {
+      const { instance } = wrapper;
 
       this.metadataScanner
         .getAllMethodNames(Object.getPrototypeOf(instance))
@@ -211,27 +218,7 @@ export class TemporalExplorer
   async handleActivities(): Promise<Record<string, Function>> {
     const activitiesMethod: Record<string, Function> = {};
 
-    const activityClasses = this.getActivityClasses();
-    const activities: InstanceWrapper[] = this.discoveryService
-      .getProviders()
-      .filter(
-        (wrapper: InstanceWrapper) =>
-          this.metadataAccessor.isActivities(
-            !wrapper.metatype || wrapper.inject
-              ? wrapper.instance?.constructor
-              : wrapper.metatype,
-          ) &&
-          (!activityClasses ||
-            activityClasses.some(
-              (cls) =>
-                cls === wrapper.metatype ||
-                (cls instanceof Object &&
-                  'metatype' in cls &&
-                  (cls as InstanceWrapper).metatype === wrapper.metatype),
-            )),
-      );
-
-    activities.forEach((wrapper: InstanceWrapper) => {
+    this.getActivityClasses().forEach((wrapper: InstanceWrapper) => {
       const { instance } = wrapper;
       const isRequestScoped = !wrapper.isDependencyTreeStatic();
 

--- a/lib/test/temporal.explorer.spec.ts
+++ b/lib/test/temporal.explorer.spec.ts
@@ -1,3 +1,4 @@
+import { Injectable, Provider } from '@nestjs/common';
 import { Test } from '@nestjs/testing';
 import { DiscoveryService, MetadataScanner, Reflector } from '@nestjs/core';
 import { TemporalExplorer } from '../temporal.explorer';
@@ -9,60 +10,81 @@ import {
 import { Activities, Activity } from '..';
 
 describe('TemporalExplorer', () => {
+  @Activities()
+  class ActivityClass1 {
+    @Activity()
+    duplicateActivity() {}
+
+    ignoredDuplicateMethod() {}
+  }
+
+  @Activities()
+  class ActivityClass2 {
+    @Activity()
+    duplicateActivity() {}
+
+    ignoredDuplicateMethod() {}
+  }
+
+  @Activities()
+  class ActivityClass3 {
+    @Activity()
+    distinctMethod() {}
+  }
+
+  @Injectable()
+  class ScheduleClient {
+    readonly namespace = 'test-namespace';
+  }
+
+  // Mirrors a real activity that derives state from an injected dependency in
+  // its constructor. It can only be built by the DI container.
+  @Injectable()
+  @Activities()
+  class ActivityWithDependencies {
+    private readonly namespace: string;
+
+    constructor(scheduleClient: ScheduleClient) {
+      this.namespace = scheduleClient.namespace;
+    }
+
+    @Activity()
+    activityUsingDependency(): string {
+      return this.namespace;
+    }
+  }
+
+  // Activity classes are registered with the DI container the same way
+  // consumers register them, and passed to the module options as the raw
+  // classes rather than as pre-built instances.
+  async function buildModule({
+    options,
+    providers = [],
+  }: {
+    options: Partial<TemporalModuleOptions>;
+    providers?: Provider[];
+  }) {
+    return await Test.createTestingModule({
+      providers: [
+        DiscoveryService,
+        TemporalExplorer,
+        TemporalMetadataAccessor,
+        Reflector,
+        MetadataScanner,
+        ...((options.activityClasses ?? []) as Provider[]),
+        ...providers,
+        {
+          provide: TEMPORAL_MODULE_OPTIONS_TOKEN,
+          useValue: {
+            workerOptions: { taskQueue: 'test-queue' },
+            ...options,
+          },
+        },
+      ],
+    }).compile();
+  }
+
   describe('findDuplicateActivityMethods', () => {
-    @Activities()
-    class ActivityClass1 {
-      @Activity()
-      duplicateActivity() {}
-
-      ignoredDuplicateMethod() {}
-    }
-
-    @Activities()
-    class ActivityClass2 {
-      @Activity()
-      duplicateActivity() {}
-
-      ignoredDuplicateMethod() {}
-    }
-
-    @Activities()
-    class ActivityClass3 {
-      @Activity()
-      distinctMethod() {}
-    }
-
-    async function buildModule({
-      options,
-    }: {
-      options: Partial<TemporalModuleOptions>;
-    }) {
-      if (options.activityClasses) {
-        options.activityClasses = options.activityClasses.map(
-          (classOrWrapper) => {
-            return { instance: new (classOrWrapper as any)() };
-          },
-        );
-      }
-
-      return await Test.createTestingModule({
-        providers: [
-          DiscoveryService,
-          TemporalExplorer,
-          TemporalMetadataAccessor,
-          Reflector,
-          MetadataScanner,
-          {
-            provide: TEMPORAL_MODULE_OPTIONS_TOKEN,
-            useValue: {
-              workerOptions: { taskQueue: 'test-queue' },
-              ...options,
-            },
-          },
-        ],
-      }).compile();
-    }
-
     it('should not throw error when errorOnDuplicateActivities is false', async () => {
       const module = await buildModule({
         options: {
@@ -97,6 +119,21 @@ describe('TemporalExplorer', () => {
           activityClasses: [ActivityClass1, ActivityClass3],
           errorOnDuplicateActivities: true,
         },
+      });
+      const temporalExplorer = module.get(TemporalExplorer);
+
+      expect(() =>
+        temporalExplorer.findDuplicateActivityMethods(),
+      ).not.toThrow();
+    });
+
+    it('should not throw error when an activity class depends on other providers', async () => {
+      const module = await buildModule({
+        options: {
+          activityClasses: [ActivityWithDependencies],
+          errorOnDuplicateActivities: true,
+        },
+        providers: [ScheduleClient],
       });
       const temporalExplorer = module.get(TemporalExplorer);
 
@@ -149,6 +186,32 @@ describe('TemporalExplorer', () => {
       expect(() => temporalExplorer.findDuplicateActivityMethods()).toThrow(
         'Activity names must be unique across all Activity classes. Identified activities with conflicting names: {"duplicate1":["MultiDuplicateClass1","MultiDuplicateClass2"],"duplicate2":["MultiDuplicateClass1","MultiDuplicateClass2"]}',
       );
+    });
+  });
+
+  describe('handleActivities', () => {
+    it('should only register the activity classes named in the options', async () => {
+      const module = await buildModule({
+        options: { activityClasses: [ActivityClass3] },
+        providers: [ActivityClass1],
+      });
+      const temporalExplorer = module.get(TemporalExplorer);
+
+      expect(Object.keys(await temporalExplorer.handleActivities())).toEqual([
+        'distinctMethod',
+      ]);
+    });
+
+    it('should bind activities to the instance held by the DI container', async () => {
+      const module = await buildModule({
+        options: { activityClasses: [ActivityWithDependencies] },
+        providers: [ScheduleClient],
+      });
+      const temporalExplorer = module.get(TemporalExplorer);
+
+      const activities = await temporalExplorer.handleActivities();
+
+      expect(activities.activityUsingDependency()).toBe('test-namespace');
     });
   });
 });


### PR DESCRIPTION
## Problem

`findDuplicateActivityMethods()` reads `wrapper.instance` from the values returned by `getActivityClasses()`, but `getActivityClasses()` returns `options.activityClasses` verbatim. Consumers pass class constructors (`activityClasses: [MyActivity]`), which have no `instance` property, so #61 was reading `undefined` for every entry.

74f661d9 addressed that by falling back to `new (classOrWrapper as new () => unknown)()`. An activity built that way is constructed outside the DI container, so it receives no dependencies. Any activity that reads one of its dependencies in the constructor now throws during worker startup:

```
TypeError: Cannot read properties of undefined (reading 'connection')
```

```ts
@Injectable()
@Activities()
export class CheckerActivity {
  private readonly scheduleClient: ScheduleClient;

  constructor(@InjectTemporalClient() private readonly temporalClient: WorkflowClient) {
    this.scheduleClient = getScheduleClient(this.temporalClient); // reads temporalClient.connection
  }
}
```

This only reproduces with `errorOnDuplicateActivities` enabled, since that is the only caller of the fallback.

## Fix

Resolve activity classes through `DiscoveryService` inside `getActivityClasses()`, so both `findDuplicateActivityMethods()` and `handleActivities()` operate on the container-managed instances. `handleActivities()` then no longer needs its own copy of the discovery filter, nor the branch that accepted either an `InstanceWrapper` or a class constructor.

## Why the tests did not catch it

The explorer spec mapped `activityClasses` into `{ instance: new Class() }` before handing them to the explorer:

```ts
options.activityClasses = options.activityClasses.map((classOrWrapper) => {
  return { instance: new (classOrWrapper as any)() };
});
```

That pre-wrapping means the class-constructor path consumers actually take was never exercised. The spec now registers the activity classes as providers and passes the raw classes, with a new case covering an activity that depends on another provider. That case fails on `main` and passes here.