### PR TITLE
fix(worker): make repeated shutdown lifecycle safe

### DIFF
--- a/lib/temporal.explorer.ts
+++ b/lib/temporal.explorer.ts
@@ -61,7 +61,9 @@ export class TemporalExplorer
     }
 
     try {
-      this.worker.shutdown();
+      if (this.worker.getState() === 'RUNNING') {
+        this.worker.shutdown();
+      }
       if (this.workerRunPromise) {
         await this.workerRunPromise;
       }

--- a/lib/test/temporal.explorer.spec.ts
+++ b/lib/test/temporal.explorer.spec.ts
@@ -9,6 +9,37 @@ import {
 import { Activities, Activity } from '..';
 
 describe('TemporalExplorer', () => {
+  async function buildModule({
+    options,
+  }: {
+    options: Partial<TemporalModuleOptions>;
+  }) {
+    if (options.activityClasses) {
+      options.activityClasses = options.activityClasses.map(
+        (classOrWrapper) => {
+          return { instance: new (classOrWrapper as any)() };
+        },
+      );
+    }
+
+    return await Test.createTestingModule({
+      providers: [
+        DiscoveryService,
+        TemporalExplorer,
+        TemporalMetadataAccessor,
+        Reflector,
+        MetadataScanner,
+        {
+          provide: TEMPORAL_MODULE_OPTIONS_TOKEN,
+          useValue: {
+            workerOptions: { taskQueue: 'test-queue' },
+            ...options,
+          },
+        },
+      ],
+    }).compile();
+  }
+
   describe('findDuplicateActivityMethods', () => {
     @Activities()
     class ActivityClass1 {
@@ -30,37 +61,6 @@ describe('TemporalExplorer', () => {
     class ActivityClass3 {
       @Activity()
       distinctMethod() {}
-    }
-
-    async function buildModule({
-      options,
-    }: {
-      options: Partial<TemporalModuleOptions>;
-    }) {
-      if (options.activityClasses) {
-        options.activityClasses = options.activityClasses.map(
-          (classOrWrapper) => {
-            return { instance: new (classOrWrapper as any)() };
-          },
-        );
-      }
-
-      return await Test.createTestingModule({
-        providers: [
-          DiscoveryService,
-          TemporalExplorer,
-          TemporalMetadataAccessor,
-          Reflector,
-          MetadataScanner,
-          {
-            provide: TEMPORAL_MODULE_OPTIONS_TOKEN,
-            useValue: {
-              workerOptions: { taskQueue: 'test-queue' },
-              ...options,
-            },
-          },
-        ],
-      }).compile();
     }
 
     it('should not throw error when errorOnDuplicateActivities is false', async () => {
@@ -149,6 +149,40 @@ describe('TemporalExplorer', () => {
       expect(() => temporalExplorer.findDuplicateActivityMethods()).toThrow(
         'Activity names must be unique across all Activity classes. Identified activities with conflicting names: {"duplicate1":["MultiDuplicateClass1","MultiDuplicateClass2"],"duplicate2":["MultiDuplicateClass1","MultiDuplicateClass2"]}',
       );
+    });
+  });
+
+  describe('onModuleDestroy', () => {
+    it('waits for an existing shutdown when lifecycle hooks overlap', async () => {
+      const module = await buildModule({ options: {} });
+      const temporalExplorer = module.get(TemporalExplorer);
+      let state = 'RUNNING';
+      let resolveWorkerRun!: () => void;
+      const workerRunPromise = new Promise<void>((resolve) => {
+        resolveWorkerRun = resolve;
+      });
+      const worker = {
+        getState: jest.fn(() => state),
+        shutdown: jest.fn(() => {
+          state = 'STOPPING';
+        }),
+      };
+      Reflect.set(temporalExplorer, 'worker', worker);
+      Reflect.set(temporalExplorer, 'workerRunPromise', workerRunPromise);
+
+      const firstDestroy = temporalExplorer.onModuleDestroy();
+      const secondDestroy = temporalExplorer.onModuleDestroy();
+      let secondDestroyResolved = false;
+      void secondDestroy.then(() => {
+        secondDestroyResolved = true;
+      });
+
+      await Promise.resolve();
+      expect(worker.shutdown).toHaveBeenCalledTimes(1);
+      expect(secondDestroyResolved).toBe(false);
+
+      resolveWorkerRun();
+      await Promise.all([firstDestroy, secondDestroy]);
     });
   });
 });


### PR DESCRIPTION
## Summary

- call `Worker.shutdown()` only while the worker is running
- keep awaiting the existing worker run promise when a later Nest lifecycle hook overlaps shutdown
- add a regression test for two overlapping `onModuleDestroy()` calls

## Why

The Temporal SDK can begin worker shutdown from its signal handler before Nest invokes `onModuleDestroy()`. Calling `shutdown()` again after the worker has entered `STOPPING` throws. The existing catch then lets the later lifecycle call return without waiting for in-flight work.

This keeps shutdown ownership with whichever path starts it first while preserving the important guarantee that every Nest lifecycle invocation waits for the worker run promise.

## Verification

- `npm test -- --runInBand`
- `npm run build`
- `npm run lint` is currently blocked on `main` because `tsconfig.eslint.json` is missing
